### PR TITLE
chore: Fix eslint error when building front

### DIFF
--- a/annotto-front/.eslintrc.js
+++ b/annotto-front/.eslintrc.js
@@ -1,11 +1,18 @@
 module.exports = {
+  root: true,
   env: {
     es2021: true,
     node: true,
+    browser: true,
   },
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 2021,
     sourceType: 'module',
+    requireConfigFile: false,
+    babelOptions: {
+      presets: ['@babel/preset-react'],
+    },
   },
   settings: {
     'import/resolver': {
@@ -14,11 +21,15 @@ module.exports = {
         paths: ['src', 'node_modules/'],
       },
     },
+    react: {
+      version: 'detect',
+    },
   },
   plugins: ['jsdoc'],
   extends: [
     'airbnb-base',
     'plugin:prettier/recommended',
+    'plugin:react/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript',
@@ -84,6 +95,7 @@ module.exports = {
       },
     ],
     'no-await-in-loop': 0,
+    'import/prefer-default-export': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
### Description

Fix eslint error when building front:
```
Failed to compile.

[eslint] Plugin "jsdoc" was conflicted between ".eslintrc.js" and "../.eslintrc.js".
```
#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ x ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### Checklist: (Feel free to delete this section upon completion)

- [ x ] I have performed a self-review of my own code
- [ x ] My code follows the style guidelines of this project (I have run `yarn lint`))
- [ x ] My changes generate no new warnings
