### PR TITLE
chore: Update gitignore file to ignore front generated files for coverage and cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,11 @@ yarn-error.log*
 
 # Jest and generic test utilities
 /coverage/
+/annotto-front/coverage/
 
 # Cypress
-/cypress/screenshots
-/cypress/videos
+/annotto-front/cypress/screenshots
+/annotto-front/cypress/videos
 
 # Istanbul
 /.nyc_output/*
@@ -43,5 +44,6 @@ yarn-error.log*
 /.env*local
 
 .data
+storage/
 
 junit.xml


### PR DESCRIPTION
### Description

The purpose of this removal request is to add to the .gitignore file those folders that should not be versioned, such as the folders used for front-end testing.