### PR TITLE
fix: Use admin-cli to make admin calls to Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## ![](annotto-front/public/static/images/logo_blue.png)nnotto
 *produced by* [La Javaness](https://www.lajavaness.com/)
 
-![GitHub](https://img.shields.io/github/license/lajavaness/annotto?logo=heartex) ![deploy](https://github.com/lajavaness/annotto-api/actions/workflows/deploy.yml/badge.svg) ![GitHub release](https://img.shields.io/github/v/release/lajavaness/annotto?include_prereleases)
+![GitHub](https://img.shields.io/github/license/lajavaness/annotto?logo=heartex) ![deploy](https://github.com/lajavaness/annotto-api/actions/workflows/deploy.yml/badge.svg) 
+![GitHub release](https://img.shields.io/github/v/release/lajavaness/annotto?include_prereleases)
 [![Dependency-Track](https://dependency-track.ops.lajavaness.com/api/v1/badge/vulns/project/7b01815b-08f2-430e-96a4-1ccb4aa52f40)](https://dependency-track.ops.lajavaness.com/projects/7b01815b-08f2-430e-96a4-1ccb4aa52f40)
 [![Codacy Security Scan](https://github.com/lajavaness/annotto/actions/workflows/codacy.yml/badge.svg)](https://github.com/lajavaness/annotto/actions/workflows/codacy.yml)
 [![CodeQL](https://github.com/lajavaness/annotto/actions/workflows/codeql.yml/badge.svg)](https://github.com/lajavaness/annotto/actions/workflows/codeql.yml)
@@ -14,6 +15,7 @@ Annotto is the only **go to** annotation tool to successfully annotate your docu
 
 # Table of contents
 1. [Start with docker](#start-with-docker)
+2. [Start with docker](#start-with-docker-with-minio)
 2. [Start for local development](#start-for-local-development)
 
 # Start with docker
@@ -51,19 +53,19 @@ yarn start:dev
 ```
 
 ### Environment variables
-| Name                         | Default                                   | Description                                                          |
-|------------------------------|-------------------------------------------|----------------------------------------------------------------------|
-| PORT                         | 5001                                      | Server listening port                                                |
-| NODE_ENV                     | development                               | NODE Environment to use "[development, test]"                        |
-| ENCRYPTION_SECRET_KEY        | aSecretKey                                | A Secret Key used to encrypt AWS creds  (symmetric)                  |
-| MONGO_URL                    | mongodb://localhost:27017/ljn_annotto_dev | Mongo connection string                                              |
-| ANNOTTO_FRONT_URL            | http://localhost:3000                     | Annotto Front base url                                               |
-| KEYCLOAK_REALM               | annotto                                   | Keycloak Realm (preconfigured if started with docker-compose_)       |
-| KEYCLOAK_AUTH_URL            | http://localhost:8080/auth                | Keycloak auth url (preconfigured if started with docker-compose_)    |
-| KEYCLOAK_CLIENT_ID           | annotto                                   | Keycloak client id (preconfigured if started with docker-compose_)   |
-| KEYCLOAK_CLIENT_SECRET       | a7b7a29d-abb0-4e21-abec-bca99a47e40e      | Keycloak client secret (preconfigured if started with docker-compose_) |
-| ANNOTTO_UPLOAD_MAX_FILE_SIZE | 1048576000                                | Max file size permitted to upload (default = 1000 * 1024 * 1024)     |
-| ANNOTTO_UPLOAD_BATCH_SIZE    | 50000                                     | Max file size permitted to upload (default = 1000 * 1024 * 1024)     |
+| Name                         | Default                                   | Description                                                                                                                |
+|------------------------------|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| PORT                         | 5001                                      | Server listening port                                                                                                      |
+| NODE_ENV                     | development                               | NODE Environment to use "[development, test]"                                                                              |
+| ENCRYPTION_SECRET_KEY        | aSecretKey                                | A Secret Key used to encrypt AWS creds  (symmetric)                                                                        |
+| MONGO_URL                    | mongodb://localhost:27017/ljn_annotto_dev | Mongo connection string                                                                                                    |
+| ANNOTTO_FRONT_URL            | http://localhost:3000                     | Annotto Front base url                                                                                                     |
+| KEYCLOAK_REALM               | annotto                                   | Keycloak Realm (preconfigured if started with docker-compose_)                                                             |
+| KEYCLOAK_AUTH_URL            | http://localhost:8080/auth                | Keycloak auth url (preconfigured if started with docker-compose_)                                                          |
+| KEYCLOAK_CLIENT_ID           | annotto                                   | Keycloak client id (preconfigured if started with docker-compose_)                                                         |
+| KEYCLOAK_ADMIN_CLI_SECRET    | a7b7a29d-abb0-4e21-abec-bca99a47e40e      | Keycloak admin-cli secret (preconfigured if started with docker-compose_). This is needed to use admin REST API for keycloak |
+| ANNOTTO_UPLOAD_MAX_FILE_SIZE | 1048576000                                | Max file size permitted to upload (default = 1000 * 1024 * 1024)                                                           |
+| ANNOTTO_UPLOAD_BATCH_SIZE    | 50000                                     | Max file size permitted to upload (default = 1000 * 1024 * 1024)                                                           |
 
 ## Users and Roles
 When starting Annotto, you will get 3 users preconfigured with three different role (`"admin"|"user"|"dataScientist'`)

--- a/config/config.ts
+++ b/config/config.ts
@@ -22,9 +22,12 @@ export default {
     realm: process.env.KEYCLOAK_REALM || 'annotto',
     'auth-server-url': process.env.KEYCLOAK_AUTH_URL || 'http://localhost:8080/auth',
     resource: process.env.KEYCLOAK_CLIENT_ID || 'annotto',
-    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET || 'a7b7a29d-abb0-4e21-abec-bca99a47e40e',
     'confidential-port': 8443,
     'ssl-required': 'external',
+    admin: {
+      resource: 'admin-cli',
+      secret: process.env.KEYCLOAK_ADMIN_CLI_SECRET,
+    },
   },
   swagger: {
     swaggerUi: '/explorer',

--- a/config/test.ts
+++ b/config/test.ts
@@ -3,4 +3,9 @@ export default {
   mongo: {
     url: process.env.MONGO_URL || 'mongodb://localhost:27017/annotto_test',
   },
+  keycloak: {
+    admin: {
+      secret: '8acab8c7-31f5-494c-a5a1-0637bb62b096',
+    },
+  },
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,8 @@ services:
       - "-Dkeycloak.migration.action=import"
       - "-Dkeycloak.migration.provider=dir"
       - "-Dkeycloak.migration.dir=/tmp/keycloak-import"
-      - "-Dkeycloak.migration.strategy=IGNORE_EXISTING"
+      - "-Dkeycloak.migration.strategy=OVERWRITE_EXISTING"
       - "-Dkeycloak.migration.usersExportStrategy=SAME_FILE"
-      - "-Dkeycloak.migration.realmName=annotto"
       - "-Dkeycloak.profile.feature.upload_scripts=enabled"
     environment:
       DB_VENDOR: POSTGRES

--- a/src/__tests__/get-oauth-token.ts
+++ b/src/__tests__/get-oauth-token.ts
@@ -14,7 +14,6 @@ const getOauthToken = async (user: { username: string; password: string }): Prom
       username: user.username,
       password: user.password,
       client_id: config.keycloak.resource,
-      client_secret: config.keycloak.clientSecret,
     },
   }
   const result = await request(options)

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -17,4 +17,13 @@ Keycloak.prototype.redirectToLogin = (req: Request) => {
   return !apiReqMatcher.test(req.originalUrl || req.url)
 }
 
-export const keycloak = new Keycloak({}, config.keycloak)
+export const keycloak = new Keycloak(
+  {},
+  {
+    'confidential-port': config.keycloak['confidential-port'],
+    'auth-server-url': config.keycloak['auth-server-url'],
+    resource: config.keycloak.resource,
+    'ssl-required': config.keycloak['ssl-required'],
+    realm: config.keycloak.realm,
+  }
+)

--- a/src/core/projects/index.ts
+++ b/src/core/projects/index.ts
@@ -177,7 +177,7 @@ export const updateItemCount = async (projectId: mongoose.Types.ObjectId) => {
   return itemCount
 }
 
-export const listUsers = async ({ projectId, token }: { projectId: ObjectIdOrString; token: string }) => {
+export const listUsers = async ({ projectId }: { projectId: ObjectIdOrString }) => {
   const project = await ProjectModel.findById(projectId).select('users admins dataScientists').lean()
   const emails: string[] = []
   if (project && project.users) emails.push(...project.users)
@@ -188,16 +188,15 @@ export const listUsers = async ({ projectId, token }: { projectId: ObjectIdOrStr
     return []
   }
 
-  const result = await UserService.find(token)
+  const result = await UserService.find()
 
-  const users = result
+  return result
     .filter((oneUser) => emails.some((oneEmail) => oneEmail === oneUser.email))
     .map((user) => ({
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
     }))
-  return users
 }
 
 export const getClient = async (clientName: string, { _user }: { _user: User }) => {
@@ -282,8 +281,7 @@ export const createProjectAndTasks = async ({ config, _user }: { config: Project
     }
 
     const project = new ProjectModel(projectPayload)
-    const retVal = saveProject(project, _user)
-    return retVal
+    return saveProject(project, _user)
   } catch (err) {
     throw new Error(
       `Project cannot be saved: project: ${config.name}\n. Caused by ${

--- a/src/middleware/projects.ts
+++ b/src/middleware/projects.ts
@@ -158,7 +158,7 @@ const getUsers = async (
 ) => {
   const { projectId } = req.params
   try {
-    const users = await listUsers({ projectId, token: req.token.token || '' })
+    const users = await listUsers({ projectId })
     res.json(users)
   } catch (error) {
     next(error)

--- a/src/middleware/user.ts
+++ b/src/middleware/user.ts
@@ -8,7 +8,7 @@ type PasswordResponse = {
 
 const index = async (req: express.Request, res: express.Response<User[]>, next: express.NextFunction) => {
   try {
-    const user = await userService.find(req.token.token || '')
+    const user = await userService.find()
     res.status(200).json(user)
   } catch (error) {
     next(error)
@@ -21,7 +21,7 @@ const getById = async (
   next: express.NextFunction
 ) => {
   try {
-    const user = await userService.findById(req.params.idUser, req.token.token || '')
+    const user = await userService.findById(req.params.idUser)
     res.status(200).json(user)
   } catch (error) {
     next(error)
@@ -34,7 +34,7 @@ const update = async (
   next: express.NextFunction
 ) => {
   try {
-    const user = await userService.update(req.params.idUser, req.body, req.token.token || '')
+    const user = await userService.update(req.params.idUser, req.body)
     res.status(200).json(user)
   } catch (error) {
     next(error)
@@ -47,7 +47,7 @@ const destroy = async (
   next: express.NextFunction
 ) => {
   try {
-    await userService.destroy(req.params.idUser, req.token.token || '')
+    await userService.destroy(req.params.idUser)
     res.status(200).end()
   } catch (error) {
     next(error)
@@ -60,7 +60,7 @@ const register = async (
   next: express.NextFunction
 ) => {
   try {
-    const user = await userService.create(req.body, req.token.token || '')
+    const user = await userService.create(req.body)
     res.status(201).json(user)
   } catch (error) {
     next(error)

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -70,7 +70,7 @@ async function _callApi(options: Options) {
 }
 
 /**
- * Fetch an admin cli to be able to use methods reserved for admin on Keycloak.
+ * Fetch an admin cli token to be able to use methods reserved for admin on Keycloak.
  * @return {string} Admin Cli access token.
  */
 const getAdminToken = async () => {

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch'
+import { stringify } from 'querystring'
 import { User } from '../types'
 import config from '../../config'
 
@@ -69,37 +70,59 @@ async function _callApi(options: Options) {
 }
 
 /**
+ * Fetch an admin cli to be able to use methods reserved for admin on Keycloak.
+ * @return {string} Admin Cli access token.
+ */
+const getAdminToken = async () => {
+  const data = stringify({
+    grant_type: 'client_credentials',
+    client_id: 'admin-cli',
+    client_secret: config.keycloak.admin.secret,
+  })
+
+  const resp = await fetch(`${config.keycloak['auth-server-url']}/realms/master/protocol/openid-connect/token`, {
+    method: 'post',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: data,
+  })
+  const json = await resp.json()
+  return json.access_token
+}
+
+/**
  * Find all users. This will call keycloak Admin Rest API and fetch all users.
- * @param {string} token Access Token with "view-users" role.
  * @returns {Promise<Array<KCUserRepresentation>>}.
  */
-const find = async (token: string): Promise<User[]> => {
+const find = async (): Promise<User[]> => {
+  const token = await getAdminToken()
   return _callApi({ path: '/users', method: 'GET', token })
 }
 
 /**
  * Fetch user by id.
  * @param {string} id User uuid as it appears in keycloak.
- * @param {string} token Access Token with "view-users" role.
  * @returns {Promise<KCUserRepresentation>}.
  */
-const findById = async (id: string, token: string) => {
+const findById = async (id: string) => {
+  const token = await getAdminToken()
   return _callApi({ path: `/users/${id}`, method: 'GET', token })
 }
 
 /**
  * Create a new user.
  * @param {KCUserRepresentation} body .
- * @param {string} token Access Token with "view-users" role.
  * @returns {Promise<KCUserRepresentation>}.
  */
-const create = async (body: KCUserRepresentation, token: string) => {
+const create = async (body: KCUserRepresentation) => {
   // Add default value necessary for KC Admin API. If they are taken care of in the front, remove this
   if (body.credentials) {
     body.credentials.type = 'password'
     body.credentials.temporary = false
   }
 
+  const token = await getAdminToken()
   return _callApi({ path: '/users', method: 'POST', token, body })
 }
 
@@ -107,20 +130,20 @@ const create = async (body: KCUserRepresentation, token: string) => {
  * Create a new user.
  * @param {string} id User uuid as it appears in keycloak.
  * @param {KCUserRepresentation} body .
- * @param {string} token Access Token with "view-users" role.
  * @returns {Promise<KCUserRepresentation>} .
  */
-const update = async (id: string, body: KCUserRepresentation, token: string) => {
+const update = async (id: string, body: KCUserRepresentation) => {
+  const token = await getAdminToken()
   return _callApi({ path: `/users/${id}`, method: 'PUT', token, body })
 }
 
 /**
  * Delete a user.
  * @param {string} id User uuid as it appears in keycloak.
- * @param {string} token Access Token with "view-users" role.
  * @returns {Promise<*>} .
  */
-const destroy = async (id: string, token: string) => {
+const destroy = async (id: string) => {
+  const token = await getAdminToken()
   return _callApi({ path: `/users/${id}`, method: 'DELETE', token })
 }
 

--- a/statics/keycloak/master-realm.json
+++ b/statics/keycloak/master-realm.json
@@ -1,0 +1,2438 @@
+{
+  "id": "master",
+  "realm": "master",
+  "displayName": "Keycloak",
+  "displayNameHtml": "<div class=\"kc-logo-text\"><span>Keycloak</span></div>",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 60,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 600,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "65170e59-84e1-41e9-83ac-39254e3784e8",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "master",
+        "attributes": {}
+      },
+      {
+        "id": "8996b782-c95c-4a55-b970-3a1d36f14999",
+        "name": "create-realm",
+        "description": "${role_create-realm}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "master",
+        "attributes": {}
+      },
+      {
+        "id": "1e9222d9-c8a6-481d-969c-44b88752262a",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "master",
+        "attributes": {}
+      },
+      {
+        "id": "35e5f55c-76d9-4947-958e-677186f4b805",
+        "name": "admin",
+        "description": "${role_admin}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "create-realm"
+          ],
+          "client": {
+            "annotto-realm": [
+              "view-identity-providers",
+              "view-authorization",
+              "query-users",
+              "query-groups",
+              "manage-realm",
+              "manage-users",
+              "create-client",
+              "query-clients",
+              "view-realm",
+              "view-users",
+              "view-events",
+              "view-clients",
+              "manage-identity-providers",
+              "manage-events",
+              "manage-clients",
+              "manage-authorization",
+              "query-realms",
+              "impersonation"
+            ],
+            "master-realm": [
+              "manage-identity-providers",
+              "view-clients",
+              "view-identity-providers",
+              "view-events",
+              "manage-authorization",
+              "manage-clients",
+              "impersonation",
+              "create-client",
+              "view-users",
+              "manage-events",
+              "view-authorization",
+              "manage-realm",
+              "manage-users",
+              "view-realm",
+              "query-clients",
+              "query-groups",
+              "query-realms",
+              "query-users"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "master",
+        "attributes": {}
+      },
+      {
+        "id": "780c950e-9283-4bfd-b708-d7a05d7c0f9b",
+        "name": "default-roles-master",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "master",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "annotto-realm": [
+        {
+          "id": "53aca826-96c7-4e5b-b626-ab48a2a3f974",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "19184e94-ea0c-4ad0-8dcb-411d6e7ac955",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "59c3349c-bb64-4ada-848a-fb625f6c1fec",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "annotto-realm": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "d038f937-f67d-45c5-83ea-9cb5ec14f788",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "f31d1781-be4b-428c-ad02-8bb0601595bb",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "e36f4f8c-f1da-497e-86ac-47e98d72357b",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "636c1e1f-1053-4027-833e-015b9cbb9be4",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "a2e17c1c-5a31-447c-a01a-915282feca0c",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "dfcd88ab-1f95-4019-8b5b-db3f0e40d2c1",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "6f511869-66c9-499b-ba64-ae0c84fa2e7c",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "42e50bd9-60d0-4ac7-af76-e6e90fb202e3",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "8c1e2d36-515f-4b10-a37b-0d729926f16e",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "3ce228a0-6b6c-463e-b93c-acad6072f230",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "9289dfad-4968-4b75-8afd-a676a92a3f4c",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "e42343de-342a-4fab-a639-6d20e3279906",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "c27fe48a-7cc2-4635-a449-f7dde0890f12",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "9d389acf-9c9e-4fe3-a02f-83a58b165337",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        },
+        {
+          "id": "3cfa30b3-8396-4d8f-b804-f0df8dc58757",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "annotto-realm": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "033d2a0f-85b0-43fe-ab5f-91ad82063395",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a4e90c0-3f2f-4637-9e0b-050f961f0680",
+          "attributes": {}
+        }
+      ],
+      "master-realm": [
+        {
+          "id": "a4773996-576e-4bb9-8a99-39687e9fc3d2",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "30532896-3620-42fd-8783-015a6400937b",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "02ced1d2-4c49-4f58-9b10-07a37815faad",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "3fd367f9-651d-4259-8c59-fecb976565fb",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "fd61ecaf-7b08-4887-93ac-9a82f85de8f0",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "396d6100-9a14-4559-90b1-f7c2b315ee66",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "master-realm": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "5f218cbc-bda9-4315-9ac5-29dce57d443a",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "364d4c75-975f-4e9b-a2bb-a55c9dbec3f4",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "b97cbbe1-aa46-4f56-9a6a-48466c2b8907",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "ddfcb141-1593-4d8b-83e9-26dd5d33900f",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "1c7a5b55-c27f-4b78-9746-09e0e7fbc33d",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "1e90c562-7a52-41a5-bbc2-0d9c3c7db496",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "0f136a12-56f9-4e70-9c2f-affcda5f4049",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "56b6afd0-fc3c-4c8b-970a-ad9ef027464f",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "d74e4709-a18d-409a-a9e8-ec5383095a76",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "a73d3c38-69c2-48d6-a755-b328b09c6ed7",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "master-realm": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "7152e3ed-5399-47f6-b9ce-5e41b9f3c47e",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        },
+        {
+          "id": "35dfb7ed-d207-4273-8007-b0fb2622a823",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "4e2b11b4-0b55-444d-b1c6-ef9946399195",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "7bab46b3-9cbe-4632-b04e-2df8d609e13a",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "732d16ea-ad9e-43e5-93c3-beef017ca200",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "4d88ff04-8b0b-41db-be65-e7bc808ab2f0",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "2e7dad01-3ca1-4863-abc9-8608dbc381e2",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "ab5e1698-f4c3-4128-8f76-cc0ab3cb8707",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        },
+        {
+          "id": "a003bf84-75e0-4bf8-abfa-a81d369c2d15",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "6583d218-5568-4f81-9aa6-1593905d0997",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "780c950e-9283-4bfd-b708-d7a05d7c0f9b",
+    "name": "default-roles-master",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "master"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "users": [
+    {
+      "id": "8e43321e-9e29-4336-9982-9fa9dc41604f",
+      "createdTimestamp": 1675264142078,
+      "username": "service-account-admin-cli",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "admin-cli",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "admin",
+        "default-roles-master"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "6583d218-5568-4f81-9aa6-1593905d0997",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/master/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/master/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d9aab005-b9a9-48d3-8951-97fa35943e9e",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/master/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/master/account/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "false",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "pkce.code.challenge.method": "S256",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "7f7c01d4-42d0-4b09-882b-caf8755f4b78",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ece9a0b3-493d-40b7-82fe-f30f36e62793",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "8acab8c7-31f5-494c-a5a1-0637bb62b096",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "false",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "511369af-bb2f-4c7b-8916-0702549034aa",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "1da226ec-f517-4eca-be71-8cd04e17217a",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c496d791-80bc-4af2-b940-06bfb214a50b",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8b8b1d16-0894-4e66-a686-cc6e2bc4c1c4",
+      "clientId": "annotto-realm",
+      "name": "annotto Realm",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "1a4e90c0-3f2f-4637-9e0b-050f961f0680",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2bc5f785-cf5f-4b39-b613-9be27997da5f",
+      "clientId": "master-realm",
+      "name": "master Realm",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "999cd81d-341d-4a6b-b1d7-b15b8ec10289",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/master/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/master/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "9960edf0-3eb8-436b-bfd1-fc79b96a2203",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "4b2d0831-0005-4ab0-8eb8-adf2122ada2c",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "7bbe559c-14f0-4541-9e73-a93028656f91",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "61eac7aa-27a9-45e2-8221-02a20e0573fc",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "723b5198-6283-4f60-9c3d-5da0d76ffba9",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "676ecd4d-a099-4ba4-9bd9-63e84c692065",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "2cf16d97-781c-45c5-a33e-c64625972779",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "89f20d1a-1637-4b9d-a789-a65381b705d8",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "a78b2f75-ae42-4da5-ad7f-a540750b0123",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b08956dc-26ec-425e-a8cb-350745ceb73a",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "65a39993-0e92-4556-9e4c-0ecef5922a01",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e1b207fc-ca2d-4e38-9fdf-cd577aed5b4e",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "707c002e-6429-4b44-b085-20e9eb3e4f71",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a8373108-bcd5-4250-a056-0808e0957362",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5771bdc2-af90-4a66-b213-318152018c5a",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "84ad9dce-08d3-4642-9144-1e9452a447aa",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8800990e-5118-4796-a394-f86a2988e0b9",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2d3607cc-12dc-41d2-821f-32f03112f3ea",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7f0eb91a-4361-4ce1-99ee-6fa0ba8191d5",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "178c7c34-7519-464d-8e63-18eb1fb7f33d",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5c241d96-9d04-482f-9567-14dc7a60fe0c",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0582c379-0b17-4bfa-8112-30d77f9f01c0",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "bfe057cd-d649-4642-96e6-7848a4b08c3c",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "2f08292a-80e3-4418-8357-65801bcf0870",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "d754b444-d451-46a2-8795-9fe93df8e2ee",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c883fbe5-1b49-4869-a6a6-b328215fa9b0",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "482fd0ed-3d60-4d3b-b561-2ed44d42fa94",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "9db45e57-a9e2-466f-8fed-b4c30375c1c3",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "d31dc6ec-6e17-42a3-9233-de3c90753334",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        },
+        {
+          "id": "ecc446fc-3639-4e7a-b28b-2332b5c51fdb",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "370934c5-1545-4f83-b9fc-7991bd83b2c7",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "3b056ab5-ceba-4681-badb-f0de84bc59e6",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "62b58577-8e29-461b-85c0-a792e6a8d086",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "9ff1a853-0716-4ff1-8730-f8ffb5558b06",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c414ac95-028c-4ddd-b99f-de766ffb31ba",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "225df046-ae7f-44e6-bb4a-02ba0eff2ce5",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "xXSSProtection": "1; mode=block",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "9cfd5d3c-c288-44a0-847a-a2c53ffa3823",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "b1b1af67-8cd2-4c94-a284-749a4ee7b0ed",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "e849f8af-b40a-47d1-9e78-463ae3d17a3c",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "aad3128c-4b95-4f73-a74d-693dd585f8ba",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "ba4cdf23-cf8a-4583-b7ea-f59e319d686f",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "de72e346-390a-4092-a09b-f0765ede358b",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0fa6bfc5-237a-45f8-939b-84aacc90c6c0",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "27e7523e-82b4-4599-9bba-a9e7e76ed1ef",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "f7e59539-dffa-4844-bd72-01c8e6fa209d",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "enc"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "1fcaebb4-2e20-45bc-9c28-210767c39e55",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "dd03b216-2777-4c4d-b3f8-ecb876e566fc",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "56a33e86-abbb-4f2d-b597-53d787064388",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "keyUse": [
+            "sig"
+          ],
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "66cce5ec-4045-4ae7-9a73-5b667e278fdc",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "89b80178-138b-4d88-bb94-3e5d1fe2552b",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f9ccdf18-91bc-4be6-8c85-f67b87e6482b",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "c77bbac9-19a9-4371-8341-f62d31804880",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "b0ac1d2f-abc3-4551-9e90-84f00a3af382",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "7fd48ff5-ce72-4df0-b060-e29561f20cbe",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "19518814-d5e4-42f6-979b-38bcc86f7488",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "22d89a0c-e521-4154-9cfe-214fbc093f20",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "0961d5c0-1cb8-4f9f-8cf0-5225ecacdeb9",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "0b22d0e4-45bd-46ed-8b63-4618ee0e32cb",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5a9014a9-880f-4868-9feb-6fba5ea01101",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "474b0813-5ffd-441e-ad28-a4e4c6ec4760",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "10720e87-827e-4c53-8d5b-55d66b22c4a5",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "045138f0-06de-4ab9-91df-e60ce599c6f0",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "1d026f57-5867-45ec-8787-cbe12aa6065e",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "62e4701e-e4c2-409a-90b8-18bb8802a97e",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "bf7406b2-7290-44aa-a287-f89076a1bb00",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "0ebc5160-71fd-4597-9177-7acb616fbe06",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "31ec34b9-c0a4-4323-907b-f7676ac8bd7f",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "59382deb-fed7-452a-85d8-526323261b2a",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "b6c65e08-ed10-42aa-9d58-d88c5a6d9d72",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "54f76acf-3818-4624-b60e-6835bff8f626",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {},
+  "keycloakVersion": "15.0.1",
+  "userManagedAccessAllowed": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}


### PR DESCRIPTION
### Description
The goal here is to use Keycloak ADMIN REST API to make admin calls like fetching users which were doing with the user's token at the moment. This is bad. Its better to use an admin token that the server creates at runtime when necessary.

Closes #30

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Added some tests locally.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
