### PR TITLE
fix: Set the signature version for AWS cli to v4, #28

### DIFF
--- a/src/core/s3-client.ts
+++ b/src/core/s3-client.ts
@@ -90,6 +90,7 @@ class S3Client {
   }
 
   // eslint-disable-next-line class-methods-use-this
+
   getSignedUrl(accessKeyId: string, secretAccessKey: string, url: string): Promise<string> {
     const s3Config = this.parseUrlParams(url)
     const config = {
@@ -98,6 +99,7 @@ class S3Client {
       endpoint: s3Config.endpoint,
       sslEnabled: false,
       s3ForcePathStyle: true,
+      signatureVersion: 'v4',
     }
     AWS.config.update(config)
     const s3 = new AWS.S3()


### PR DESCRIPTION
### Description

AWS4-HMAC-SHA256, also known as Signature Version 4, ("V4") is one of two authentication schemes supported by S3.

All regions support V4, but US-Standard¹, and many -- but not all -- other regions, also support the other, older scheme, Signature Version 2 ("V2").

According to http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html ... new S3 regions deployed after January, 2014 will only support V4.

So we forced the signature version here.

Closes #28

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
