### PR TITLE
fix: Remove name of realm to be imported so all realms will be imported

### DIFF
--- a/bundle/bin/start.sh
+++ b/bundle/bin/start.sh
@@ -6,7 +6,6 @@
 -Dkeycloak.migration.dir=/tmp/keycloak-import \
 -Dkeycloak.migration.strategy=IGNORE_EXISTING \
 -Dkeycloak.migration.usersExportStrategy=SAME_FILE \
--Dkeycloak.migration.realmName=annotto \
 -Dkeycloak.profile.feature.upload_scripts=enabled &
 
 /usr/sbin/nginx -g 'daemon off;' &


### PR DESCRIPTION
This PR removes the argument line for the realm name on Keycloak start script. It doesnt need any name as we added the **master** realm in the realms to be imported in addition to **annotto**. So now that there are multiple realms to imported, the argument line is not needed otherwise its gonna throw an error.

Closes #38 