### PR TITLE
fix: Add missing secret for Master Realm Admin cli on Keycloak

### DIFF
--- a/bundle/Dockerfile.full
+++ b/bundle/Dockerfile.full
@@ -38,6 +38,7 @@ ENV ANNOTTO_FRONT_URL "http://localhost:3000"
 ENV KEYCLOAK_AUTH_URL "http://localhost:3000/auth"
 ENV KEYCLOAK_ADMIN_URL  "http://localhost:3000/auth/realms/master/admin/"
 ENV KEYCLOAK_FRONTEND_URL "http://localhost:3000/auth"
+ENV KEYCLOAK_ADMIN_CLI_SECRET "8acab8c7-31f5-494c-a5a1-0637bb62b096"
 
 WORKDIR /opt
 


### PR DESCRIPTION

### Description
The bundle was missing the KEYCLOAK_ADMIN_CLI_SECRET to correctly make admin calls to Keycloak.

Closes #42

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Tested locally, clicked on item on the home page, item was loading correctly.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
