### PR TITLE
feat: Add management of overlaps on NER annotations, 45

### DIFF
--- a/annotto-front/src/modules/project/components/common/NerMark.js
+++ b/annotto-front/src/modules/project/components/common/NerMark.js
@@ -1,0 +1,115 @@
+import { CheckOutlined, CloseOutlined } from '@ant-design/icons'
+import { isNumber } from 'lodash'
+import React, { forwardRef } from 'react'
+import PropTypes from 'prop-types'
+
+import * as Styled from 'modules/project/components/common/__styles__/NerContainer.styles'
+
+const NerMark = (
+  {
+    task,
+    annotationIndex,
+    predictionIndex,
+    isFirstMark,
+    isLastMark,
+    isSourceRelation,
+    children,
+    isHighlight,
+    isPredictionHovered,
+    isAnnotationHovered,
+    showPredictions,
+    onMouseClick,
+    onMouseLeave,
+    onCloseClick,
+    onMouseOver,
+    onValidateClick,
+  },
+  ref
+) => {
+  return (
+    <Styled.MarkContainer
+      data-testid={`__ner-mark__${annotationIndex}`}
+      ref={ref}
+      onMouseOver={onMouseOver}
+      onClick={onMouseClick}
+      onMouseLeave={onMouseLeave}
+      backgroundColor={task.color}
+      $isHovered={isAnnotationHovered(annotationIndex)}
+      $isPrediction={!isNumber(annotationIndex) && isNumber(predictionIndex)}
+      isSourceRelation={isSourceRelation}
+    >
+      <Styled.Mark
+        $isHighlight={isHighlight}
+        $isFirstMarkSelected={isFirstMark}
+        $isHovered={isAnnotationHovered(annotationIndex)}
+      >
+        {children}
+      </Styled.Mark>
+      {isLastMark && (
+        <Styled.TaskLabel>
+          {task.label}
+          {isNumber(predictionIndex) && showPredictions && <Styled.PredictionIcon />}
+          {isAnnotationHovered(annotationIndex) && (
+            <Styled.ActionButton onClick={onCloseClick} icon={<CloseOutlined />} type="primary" shape="circle" />
+          )}
+          {!isNumber(annotationIndex) && isPredictionHovered(predictionIndex) && (
+            <Styled.ActionButton onClick={onValidateClick} icon={<CheckOutlined />} type="primary" shape="circle" />
+          )}
+        </Styled.TaskLabel>
+      )}
+    </Styled.MarkContainer>
+  )
+}
+
+export default forwardRef(NerMark)
+
+const TaskValue = PropTypes.string
+
+export const TaskShape = PropTypes.shape({
+  /** A machine-readable key that identifies the label in the backend, and that
+   * is unique among the siblings of the task (but that can be used.
+   * for other child nodes of other tasks). */
+  value: TaskValue.isRequired,
+  /** The text displayed in the list for annotators to recognise. */
+  label: PropTypes.string.isRequired,
+  /** A keyboard shortcut that is bound when the list is displayed to toggle.
+   * this annotation. */
+  hotkey: PropTypes.string,
+  /** Defines the color of the task object.
+   * It's used to define the background of the label relation.
+   * Hexadecimal format.
+   * If the color does not exist we use the default colors defined in the theme. */
+  color: PropTypes.string,
+  /** If a task is not top-level, it may contain shortcuts to the value.
+   * of its parents to simplify algorithms. */
+  parents: PropTypes.arrayOf(TaskValue),
+})
+
+export const CharAnnotationShape = {
+  annotationIndex: PropTypes.number,
+  predictionIndex: PropTypes.number,
+  isFirstMark: PropTypes.bool.isRequired,
+  isLastMark: PropTypes.bool.isRequired,
+  isSourceRelation: PropTypes.bool.isRequired,
+}
+
+export const HandlerNerMarkShape = {
+  onMouseClick: PropTypes.func.isRequired,
+  onMouseLeave: PropTypes.func.isRequired,
+  onCloseClick: PropTypes.func.isRequired,
+  onMouseOver: PropTypes.func.isRequired,
+  onValidateClick: PropTypes.func.isRequired,
+}
+
+NerMark.propTypes = {
+  ...CharAnnotationShape,
+  isHighlight: PropTypes.bool,
+  task: TaskShape.isRequired,
+  children: PropTypes.node,
+  isPredictionHovered: PropTypes.func.isRequired,
+  isAnnotationHovered: PropTypes.func.isRequired,
+  showPredictions: PropTypes.bool.isRequired,
+  ...HandlerNerMarkShape,
+}
+
+export const NerMarkPropTypes = NerMark.propTypes

--- a/annotto-front/src/modules/project/components/common/NerMarks.js
+++ b/annotto-front/src/modules/project/components/common/NerMarks.js
@@ -1,0 +1,129 @@
+import { isEmpty, isNumber } from 'lodash'
+import React, { forwardRef, useCallback } from 'react'
+import PropTypes from 'prop-types'
+
+import { isNerAnnotationEquivalent } from 'shared/utils/annotationUtils'
+
+import NerMark, {
+  CharAnnotationShape,
+  HandlerNerMarkShape,
+  NerMarkPropTypes,
+  TaskShape,
+} from 'modules/project/components/common/NerMark'
+
+import theme from '__theme__'
+
+import * as Styled from 'modules/project/components/common/__styles__/NerContainer.styles'
+
+const NerMarks = (
+  {
+    annotationMarks,
+    tasks,
+    isPredictionHovered,
+    isAnnotationHovered,
+    sourceRelation,
+    showPredictions,
+    onMouseClick,
+    onMouseLeave,
+    onCloseClick,
+    onMouseOver,
+    onValidateClick,
+  },
+  setRef
+) => {
+  const getTask = useCallback(
+    (taskValue) => {
+      const task = tasks.find(({ value }) => value === taskValue)
+
+      if (task && !task.color) {
+        task.color = theme.colors.defaultAnnotationColors[tasks.findIndex((t) => t.value === task.value)]
+      }
+
+      return task
+    },
+    [tasks]
+  )
+
+  return (
+    !isEmpty(annotationMarks) &&
+    annotationMarks.map(({ value, isHighlight, charAnnotations }, index) => {
+      if (!isEmpty(charAnnotations)) {
+        return charAnnotations.reduce((result, charAnnotation, markIndex) => {
+          const { annotationIndex, predictionIndex, taskValue, start, end } = charAnnotation
+          const task = getTask(taskValue)
+
+          const isSourceRelation = isNerAnnotationEquivalent(sourceRelation, {
+            value: taskValue,
+            ner: { start, end },
+          })
+
+          return (
+            <NerMark
+              ref={setRef(index - markIndex, annotationIndex)}
+              key={`mark_${index}_${markIndex}`}
+              task={task}
+              {...charAnnotation}
+              isHighlight={isHighlight}
+              isPredictionHovered={isPredictionHovered}
+              isAnnotationHovered={isAnnotationHovered}
+              isSourceRelation={isSourceRelation}
+              showPredictions={showPredictions}
+              onMouseClick={onMouseClick(annotationIndex)}
+              onMouseLeave={onMouseLeave(isNumber(annotationIndex))}
+              onCloseClick={onCloseClick(annotationIndex)}
+              onMouseOver={onMouseOver(
+                isNumber(annotationIndex) ? annotationIndex : predictionIndex,
+                isNumber(annotationIndex)
+              )}
+              onValidateClick={onValidateClick(predictionIndex)}
+            >
+              {markIndex === 0 ? value : result}
+            </NerMark>
+          )
+        }, null)
+      }
+      return (
+        <Styled.Span ref={setRef(index)} $isHighlight={isHighlight} key={index}>
+          {value}
+        </Styled.Span>
+      )
+    })
+  )
+}
+
+export default forwardRef(NerMarks)
+
+export const AnnotationShape = PropTypes.shape({
+  /** A machine-readable key that identifies the label in the backend, and that
+   * is unique among the siblings of the task (but that can be used.
+   * for other child nodes of other tasks). */
+  value: PropTypes.string.isRequired,
+  /** Contains data used to display selections on words. */
+  ner: PropTypes.shape({
+    /** Number indicating the beginning of the word. */
+    start: PropTypes.number.isRequired,
+    /** Number indicating the end of the word. */
+    end: PropTypes.number.isRequired,
+  }),
+})
+
+NerMarks.propTypes = {
+  annotationMarks: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      isHighlight: NerMarkPropTypes.isHighlight,
+      charAnnotations: PropTypes.arrayOf(
+        PropTypes.shape({ ...CharAnnotationShape, start: PropTypes.number, end: PropTypes.number })
+      ),
+    })
+  ),
+  sourceRelation: AnnotationShape,
+  annotations: PropTypes.arrayOf(AnnotationShape),
+  tasks: PropTypes.arrayOf(TaskShape),
+  isPredictionHovered: NerMarkPropTypes.isPredictionHovered,
+  isAnnotationHovered: NerMarkPropTypes.isAnnotationHovered,
+  showPrediction: NerMarkPropTypes.showPredictions,
+  ...HandlerNerMarkShape,
+}
+
+NerMarks.defaultProps = {}

--- a/annotto-front/src/modules/project/components/common/__styles__/NerContainer.styles.js
+++ b/annotto-front/src/modules/project/components/common/__styles__/NerContainer.styles.js
@@ -1,6 +1,5 @@
 import { Button } from 'antd'
 import { TagsOutlined } from '@ant-design/icons'
-import { isNil } from 'lodash'
 import styled from '@xstyled/styled-components'
 
 export const Root = styled.div`
@@ -32,10 +31,9 @@ export const Svg = styled.svg`
 export const MarkContainer = styled.span`
   cursor: pointer;
   ${(props) => ({ ...props.theme.fonts.regular })};
-  background-color: ${({ $isPrediction, backgroundColor }) => ($isPrediction ? '#00000024' : backgroundColor)};
+  background-color: ${({ $isPrediction, backgroundColor }) => ($isPrediction ? '#00000024' : `${backgroundColor}80`)};
   outline: ${({ $isPrediction, backgroundColor }) => $isPrediction && `1px dashed ${backgroundColor}`};
   outline-offset: ${({ $isPrediction }) => $isPrediction && `-1px`};
-  padding: 2px 0;
   line-height: 20px;
   background-image: ${({ $isPrediction }) =>
     $isPrediction &&
@@ -46,7 +44,7 @@ export const MarkContainer = styled.span`
   ${({ $isHovered, theme, backgroundColor }) =>
     $isHovered && `color: ${theme.fonts.regular.color}; background-color: ${backgroundColor}CC`};
   display: inline-block;
-  ${({ margin }) => !isNil(margin) && `margin-${margin}: 50px;`};
+  height: 24px;
   ${({ isSourceRelation, theme }) => isSourceRelation && `box-shadow: inset 0px 0px 0px 1px ${theme.colors.primary};`};
 `
 
@@ -62,11 +60,12 @@ export const Span = styled.span`
   ${({ $isHighlight, theme }) => $isHighlight && `background-color: ${theme.colors.highlight}; padding: 2px 0;`};
 `
 
-export const TaskLabel = styled.span`
+export const TaskLabel = styled.sup`
   position: relative;
   user-select: none;
   margin: 0 2px;
-  ${({ theme }) => ({ ...theme.fonts.superscript })}
+  top: 0;
+  ${({ theme }) => ({ ...theme.fonts.superscript })};
 `
 
 export const Space = styled.span`

--- a/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/NerContainer.test.js.snap
+++ b/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/NerContainer.test.js.snap
@@ -8,11 +8,7 @@ exports[`NerContainer matches snapshot 1`] = `
   >
     <p
       class="sc-iWOQzb bBzUZr"
-    >
-      <span
-        class="sc-dTjBdT fHgdjK"
-      />
-    </p>
+    />
   </div>
 </DocumentFragment>
 `;

--- a/annotto-front/src/modules/project/components/pages/AnnotationPage.js
+++ b/annotto-front/src/modules/project/components/pages/AnnotationPage.js
@@ -60,11 +60,7 @@ import {
 } from 'modules/project/actions/annotationActions'
 import { openFilterModal, openGuideModal, putProject } from 'modules/project/actions/projectActions'
 
-import {
-  doesOverlapWithCurrentAnnotations,
-  isAnnotationNer,
-  isPredictionEquivalentToAnnotation,
-} from 'shared/utils/annotationUtils'
+import { isAnnotationNer, isPredictionEquivalentToAnnotation } from 'shared/utils/annotationUtils'
 
 import SettingsDrawer from 'modules/project/components/common/SettingsDrawer'
 
@@ -142,8 +138,7 @@ const AnnotationPage = ({ setHeaderActions }) => {
           ? currentItemPredictions.reduce(
               (result, prediction) =>
                 !annotations.some((annotation) => isPredictionEquivalentToAnnotation(annotation, prediction)) &&
-                (!isAnnotationNer(prediction) ||
-                  isEmpty(doesOverlapWithCurrentAnnotations(annotations, prediction.ner.start, prediction.ner.end)))
+                !isAnnotationNer(prediction)
                   ? [...result, prediction]
                   : result,
               annotations

--- a/annotto-front/src/modules/project/hooks/__tests__/useNerDimensions.test.js
+++ b/annotto-front/src/modules/project/hooks/__tests__/useNerDimensions.test.js
@@ -1,0 +1,104 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import useNerDimensions from 'modules/project/hooks/useNerDimensions'
+
+describe('useNerDimensions', () => {
+  let rootRef
+  let contentRef
+  let rootDiv
+  let contentDiv
+
+  const width = 100
+  const height = 50
+  const contentBoundingClientRect = {
+    x: 0,
+    y: 0,
+    width,
+    height,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  }
+
+  beforeEach(() => {
+    rootDiv = document.createElement('div')
+    document.body.appendChild(rootDiv)
+
+    rootDiv.style.width = `${width}px`
+    rootDiv.style.height = `${height}px`
+    rootDiv.style.paddingLeft = '10px'
+    rootDiv.style.paddingRight = '10px'
+    rootDiv.style.paddingTop = '10px'
+    rootDiv.style.paddingBottom = '10px'
+    rootDiv.style.borderLeftWidth = '10px'
+    rootDiv.style.borderRightWidth = '10px'
+    rootDiv.style.borderTopWidth = '10px'
+    rootDiv.style.borderBottomWidth = '10px'
+
+    contentDiv = rootDiv.appendChild(document.createElement('div'))
+
+    contentDiv.getBoundingClientRect = jest.fn(() => contentBoundingClientRect)
+
+    rootRef = { current: rootDiv }
+    contentRef = { current: contentDiv }
+  })
+
+  afterEach(() => {
+    document.body.removeChild(rootDiv)
+    rootRef = null
+    contentRef = null
+    // rootDiv = null
+    contentDiv = null
+  })
+
+  it('should return the root and content dimensions', async () => {
+    const { result } = renderHook(() => useNerDimensions(rootRef, contentRef, []))
+
+    expect(result.current).toEqual([
+      {
+        height: 10,
+        width: 60,
+      },
+      contentBoundingClientRect,
+    ])
+  })
+
+  it('should return undefined for root and content dimensions if rootRef and contentRef are undefined', async () => {
+    const { result } = renderHook(() => useNerDimensions())
+
+    expect(result.current).toEqual([undefined, undefined])
+  })
+
+  it('should rerender when deps change', async () => {
+    const { result, rerender } = renderHook(() => useNerDimensions(rootRef, contentRef, []))
+
+    expect(result.current).toEqual([
+      {
+        height: 10,
+        width: 60,
+      },
+      contentBoundingClientRect,
+    ])
+
+    rerender({
+      rootRef,
+      contentRef,
+      deps: undefined,
+    })
+
+    expect(result.current).toEqual([
+      {
+        height: 10,
+        width: 60,
+      },
+      contentBoundingClientRect,
+    ])
+
+    rerender({
+      rootRef,
+      contentRef,
+      deps: ['foo'],
+    })
+  })
+})

--- a/annotto-front/src/modules/project/hooks/useNerDimensions.js
+++ b/annotto-front/src/modules/project/hooks/useNerDimensions.js
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const useNerDimensions = (rootRef, contentRef, deps = []) => {
+  const [rootDimensions, setRootDimensions] = useState()
+  const [contentDimensions, setContentDimensions] = useState()
+
+  const resizeRootDimensions = (node) => {
+    const cs = getComputedStyle(node)
+
+    const paddingX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight)
+    const paddingY = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom)
+
+    const borderX = parseFloat(cs.borderLeftWidth) + parseFloat(cs.borderRightWidth)
+    const borderY = parseFloat(cs.borderTopWidth) + parseFloat(cs.borderBottomWidth)
+
+    const width = parseFloat(cs.width) - paddingX - borderX
+    const height = parseFloat(cs.height) - paddingY - borderY
+
+    setRootDimensions({ width, height })
+  }
+
+  const _onWindowResize = useCallback(() => {
+    if (rootRef?.current) {
+      resizeRootDimensions(rootRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (contentRef?.current) {
+      setContentDimensions(contentRef.current.getBoundingClientRect())
+    }
+  }, [rootDimensions])
+
+  useEffect(() => {
+    if (rootRef?.current) {
+      resizeRootDimensions(rootRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('resize', _onWindowResize)
+
+    return () => window.removeEventListener('resize', _onWindowResize)
+  }, [_onWindowResize])
+
+  useEffect(() => {
+    _onWindowResize()
+  }, [_onWindowResize, ...deps])
+
+  return [rootDimensions, contentDimensions]
+}
+
+export default useNerDimensions

--- a/annotto-front/src/modules/project/services/__tests__/nerAnnotationServices.test.js
+++ b/annotto-front/src/modules/project/services/__tests__/nerAnnotationServices.test.js
@@ -1,0 +1,274 @@
+import {
+  doesAnnotationNerAlreadyExist,
+  getAnnotationIndex,
+  getAnnotationMarkNode,
+  getTextNodes,
+  sortAndFilterNerByStart,
+  splitContentToAnnotationMarks,
+} from 'modules/project/services/nerAnnotationServices'
+
+describe('nerAnnotationServices', () => {
+  describe('splitContentToAnnotationMarks', () => {
+    it('should return an empty array if the input string is empty', () => {
+      expect(splitContentToAnnotationMarks('')).toEqual([])
+    })
+
+    it('should return string in object if annotations is empty', () => {
+      const string = 'foo'
+      expect(splitContentToAnnotationMarks(string)).toEqual([{ charAnnotations: [], isHighlight: false, value: 'foo' }])
+    })
+
+    it('should correctly split the input string into an array of characters with their annotations and highlights', () => {
+      const string = 'Hello World'
+      const annotations = [
+        {
+          ner: {
+            start: 0,
+            end: 5,
+          },
+          taskValue: 'Greeting',
+          task: 'Annotation',
+        },
+        {
+          ner: {
+            start: 6,
+            end: 11,
+          },
+          taskValue: 'Earth',
+          task: 'Annotation',
+        },
+      ]
+      const highlights = [
+        {
+          start: 0,
+          end: 10,
+          score: 0.9,
+        },
+      ]
+
+      const result = splitContentToAnnotationMarks(string, annotations, highlights)
+
+      expect(result).toEqual([
+        {
+          charAnnotations: [
+            {
+              end: 5,
+              isFirstMark: true,
+              isLastMark: true,
+              start: 0,
+            },
+          ],
+          isHighlight: true,
+          value: 'Hello',
+        },
+        {
+          charAnnotations: [],
+          isHighlight: true,
+          value: ' ',
+        },
+        {
+          charAnnotations: [
+            {
+              end: 11,
+              isFirstMark: true,
+              isLastMark: false,
+              start: 6,
+            },
+          ],
+          isHighlight: true,
+          value: 'Worl',
+        },
+        {
+          charAnnotations: [
+            {
+              end: 11,
+              isFirstMark: false,
+              isLastMark: true,
+              start: 6,
+            },
+          ],
+          isHighlight: false,
+          value: 'd',
+        },
+      ])
+    })
+  })
+
+  describe('doesAnnotationNerAlreadyExist', () => {
+    it('returns true when the annotation to check is in the annotations list', () => {
+      expect(
+        doesAnnotationNerAlreadyExist([{ value: 'John', ner: { start: 0, end: 3 } }], {
+          value: 'John',
+          ner: { start: 0, end: 3 },
+        })
+      ).toBeTruthy()
+    })
+
+    it('returns false when the annotation to check is not in the annotations list', () => {
+      expect(
+        doesAnnotationNerAlreadyExist([{ value: 'John', ner: { start: 0, end: 3 } }], {
+          value: 'Jane',
+          ner: { start: 0, end: 3 },
+        })
+      ).toBeFalsy()
+    })
+  })
+
+  describe('getTextNodes', () => {
+    let div
+    let textNode1
+    let textNode2
+    let supNode
+
+    beforeEach(() => {
+      div = document.createElement('div')
+      textNode1 = document.createTextNode('text node 1')
+      textNode2 = document.createTextNode('text node 2')
+      supNode = document.createElement('sup')
+      supNode.appendChild(textNode2)
+      div.appendChild(textNode1)
+      div.appendChild(supNode)
+    })
+
+    it('returns only text nodes with parent tagName different from SUP', () => {
+      const textNodes = getTextNodes(div)
+      expect(textNodes).toHaveLength(1)
+      expect(textNodes[0]).toBe(textNode1)
+    })
+
+    it('returns an empty array for a node without text nodes', () => {
+      const emptyNode = document.createElement('empty')
+      const textNodes = getTextNodes(emptyNode)
+      expect(textNodes).toHaveLength(0)
+    })
+  })
+
+  describe('getAnnotationMarkNode', () => {
+    it('returns the node with the specified annotationIndex', () => {
+      const nodes = [
+        { annotationIndex: 1, node: { id: 'node1' } },
+        { annotationIndex: 2, node: { id: 'node2' } },
+        { annotationIndex: 3, node: { id: 'node3' } },
+      ]
+      const annotationIndex = 2
+      const result = getAnnotationMarkNode(annotationIndex, nodes)
+      expect(result).toEqual({ id: 'node2' })
+    })
+
+    it('returns null if no node has the specified annotationIndex', () => {
+      const nodes = [
+        { annotationIndex: 1, node: { id: 'node1' } },
+        { annotationIndex: 2, node: { id: 'node2' } },
+        { annotationIndex: 3, node: { id: 'node3' } },
+      ]
+      const annotationIndex = 4
+      const result = getAnnotationMarkNode(annotationIndex, nodes)
+      expect(result).toBeNull()
+    })
+
+    it('returns null if nodes is empty', () => {
+      const nodes = []
+      const annotationIndex = 2
+      const result = getAnnotationMarkNode(annotationIndex, nodes)
+      expect(result).toBeNull()
+    })
+
+    it('returns null if annotationIndex is not defined', () => {
+      const nodes = [
+        { annotationIndex: 1, node: { id: 'node1' } },
+        { annotationIndex: 2, node: { id: 'node2' } },
+        { annotationIndex: 3, node: { id: 'node3' } },
+      ]
+      const annotationIndex = undefined
+      const result = getAnnotationMarkNode(annotationIndex, nodes)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getAnnotationIndex', () => {
+    const annotations = [
+      { value: 'John Doe', ner: { start: 1, end: 5 } },
+      { value: 'Jane Doe', ner: { start: 6, end: 10 } },
+    ]
+
+    const annotationToFind = { value: 'Jane Doe', ner: { start: 6, end: 10 } }
+
+    it('returns the index of the specified annotation', () => {
+      const result = getAnnotationIndex(annotationToFind, annotations)
+      expect(result).toBe(1)
+    })
+
+    const falsyCases = [
+      ['the specified annotation is not found', { value: 'Event', ner: { start: 16, end: 20 } }, annotations],
+      ['annotations is empty', annotationToFind, []],
+      ['annotations is undefined', annotationToFind, undefined],
+    ]
+
+    it.each(falsyCases)('return -1 if %s', (title, input1, input2) => {
+      expect(getAnnotationIndex(input1, input2)).toBe(-1)
+    })
+  })
+
+  describe('sortNerByStart', () => {
+    const cases = [
+      {
+        title: 'returns input if input is a number',
+        input: 1,
+      },
+      { title: 'returns input if input is null', input: null },
+      {
+        title: 'returns input if input is undefined',
+        input: undefined,
+      },
+      {
+        title: 'returns input if input is an empty object',
+        input: {},
+      },
+      {
+        title: 'returns input if input is an empty array',
+        input: [],
+      },
+      {
+        title: 'returns input if input is a string',
+        input: 'toto',
+      },
+      {
+        title: 'returns input if input an empty string',
+        input: '',
+      },
+    ]
+
+    cases.forEach(({ title, input }) => {
+      it(title, () => {
+        expect(sortAndFilterNerByStart(input)).toEqual(input)
+      })
+    })
+
+    it('returns filtered input', () => {
+      const input = [{ name: 'bar' }, { name: 'foo', ner: { start: 1 } }]
+      const output = [{ name: 'foo', ner: { start: 1 } }]
+      expect(sortAndFilterNerByStart(input)).toEqual(output)
+    })
+
+    it('returns sorted input', () => {
+      const input = [
+        { name: 'bar', ner: { start: 2 } },
+        { name: 'foo', ner: { start: 1 } },
+      ]
+      const output = [
+        { name: 'foo', ner: { start: 1 } },
+        { name: 'bar', ner: { start: 2 } },
+      ]
+      expect(sortAndFilterNerByStart(input)).toEqual(output)
+    })
+
+    it('returns filtered and sorted input', () => {
+      const input = [{ name: 'bar', ner: { start: 2 } }, { name: 'foo', ner: { start: 1 } }, { name: 'zog' }]
+      const output = [
+        { name: 'foo', ner: { start: 1 } },
+        { name: 'bar', ner: { start: 2 } },
+      ]
+      expect(sortAndFilterNerByStart(input)).toEqual(output)
+    })
+  })
+})

--- a/annotto-front/src/modules/project/services/nerAnnotationServices.js
+++ b/annotto-front/src/modules/project/services/nerAnnotationServices.js
@@ -1,0 +1,98 @@
+import { isArray, isEmpty, isEqualWith, isNil } from 'lodash'
+import { isNerAnnotationEquivalent } from 'shared/utils/annotationUtils'
+
+export const sortAndFilterNerByStart = (input) => {
+  if (!isArray(input) || isEmpty(input)) return input
+  return input.filter(({ ner }) => !!ner).sort(({ ner: { start: a } }, { ner: { start: b } }) => a - b)
+}
+
+const isHighlighted = (charIndex, highlights) =>
+  !isEmpty(highlights) && highlights.some(({ start, end }) => start <= charIndex && charIndex < end)
+
+export const getCharAnnotations = (charIndex, annotations) => {
+  if (isEmpty(annotations) || isNil(charIndex)) {
+    return []
+  }
+
+  return annotations.reduce(
+    (result, { value: taskValue, ner: { start, end }, annotationIndex, predictionIndex }) =>
+      start <= charIndex && charIndex < end
+        ? [
+            ...result,
+            {
+              taskValue,
+              annotationIndex,
+              predictionIndex,
+              isFirstMark: start === charIndex,
+              isLastMark: end - 1 === charIndex,
+              start,
+              end,
+            },
+          ]
+        : result,
+    []
+  )
+}
+
+export const splitContentToAnnotationMarks = (string, annotations, highlights) => {
+  if (isEmpty(string)) {
+    return []
+  }
+
+  return string.split('').reduce((result, char, i) => {
+    const charAnnotations = getCharAnnotations(i, annotations)
+    const charHighlight = isHighlighted(i, highlights)
+    if (
+      isEmpty(result) ||
+      !isEqualWith(charAnnotations, result.at(-1).charAnnotations, (a, b, key) =>
+        key === 'isFirstMark' || key === 'isLastMark' ? true : undefined
+      ) ||
+      charHighlight !== result.at(-1).isHighlight
+    ) {
+      result.push({
+        value: char,
+        charAnnotations,
+        isHighlight: charHighlight,
+      })
+    } else {
+      const lastItem = result.at(-1)
+      lastItem.value += char
+      lastItem.isHighlight = lastItem.isHighlight || charHighlight
+      lastItem.charAnnotations = lastItem.charAnnotations.map((ca) => ({
+        ...ca,
+        isLastMark: charAnnotations.find(({ taskValue }) => taskValue === ca.taskValue)?.isLastMark ?? ca.isLastMark,
+      }))
+    }
+    return result
+  }, [])
+}
+
+export const doesAnnotationNerAlreadyExist = (annotations, annotationToCheck) =>
+  annotations.some((annotation) => isNerAnnotationEquivalent(annotation, annotationToCheck))
+
+export const getTextNodes = (node) => {
+  let textNodes = []
+  if (node.nodeType === Node.TEXT_NODE && node.parentNode.tagName !== 'SUP') {
+    textNodes.push(node)
+  } else {
+    Array.from(node.childNodes).forEach((child) => {
+      textNodes = [...textNodes, ...getTextNodes(child)]
+    })
+  }
+  return textNodes
+}
+
+export const getAnnotationMarkNode = (annotationIndex, nodes) => {
+  if (!isNil(annotationIndex) && !isEmpty(nodes)) {
+    return nodes.filter((node) => node?.annotationIndex === annotationIndex).at(-1)?.node || null
+  }
+
+  return null
+}
+
+export const getAnnotationIndex = (annotationToFind, annotations) => {
+  if (!isNil(annotationToFind) && !isEmpty(annotations)) {
+    return annotations.findIndex((annotation) => isNerAnnotationEquivalent(annotation, annotationToFind))
+  }
+  return -1
+}

--- a/annotto-front/src/shared/utils/__tests__/annotationUtils.test.js
+++ b/annotto-front/src/shared/utils/__tests__/annotationUtils.test.js
@@ -4,80 +4,15 @@ import {
   _isNerAnnotationEquivalent,
   _isTextAnnotationEquivalent,
   _isZoneEquivalent,
-  doesOverlapWithCurrentAnnotations,
   isAnnotationNer,
   isClassificationAnnotationEquivalent,
   isEntitiesRelationEquivalent,
   isNerAnnotationEquivalent,
   isPredictionEquivalentToAnnotation,
   isZoneAnnotationEquivalent,
-  sortAndFilterNerByStart,
 } from 'shared/utils/annotationUtils'
 
 describe('annotationUtils', () => {
-  describe('sortNerByStart', () => {
-    const cases = [
-      {
-        title: 'returns input if input is a number',
-        input: 1,
-      },
-      { title: 'returns input if input is null', input: null },
-      {
-        title: 'returns input if input is undefined',
-        input: undefined,
-      },
-      {
-        title: 'returns input if input is an empty object',
-        input: {},
-      },
-      {
-        title: 'returns input if input is an empty array',
-        input: [],
-      },
-      {
-        title: 'returns input if input is a string',
-        input: 'toto',
-      },
-      {
-        title: 'returns input if input an empty string',
-        input: '',
-      },
-    ]
-
-    cases.forEach(({ title, input }) => {
-      it(title, () => {
-        expect(sortAndFilterNerByStart(input)).toEqual(input)
-      })
-    })
-
-    it('returns filtered input', () => {
-      const input = [{ name: 'bar' }, { name: 'foo', ner: { start: 1 } }]
-      const output = [{ name: 'foo', ner: { start: 1 } }]
-      expect(sortAndFilterNerByStart(input)).toEqual(output)
-    })
-
-    it('returns sorted input', () => {
-      const input = [
-        { name: 'bar', ner: { start: 2 } },
-        { name: 'foo', ner: { start: 1 } },
-      ]
-      const output = [
-        { name: 'foo', ner: { start: 1 } },
-        { name: 'bar', ner: { start: 2 } },
-      ]
-      expect(sortAndFilterNerByStart(input)).toEqual(output)
-    })
-
-    it('returns filtered and sorted input', () => {
-      const input = [{ name: 'bar', ner: { start: 2 } }, { name: 'foo', ner: { start: 1 } }, { name: 'zog' }]
-      const output = [
-        { name: 'foo', ner: { start: 1 } },
-        { name: 'bar', ner: { start: 2 } },
-      ]
-      expect(sortAndFilterNerByStart(input)).toEqual(output)
-    })
-  })
-
   describe('isAnnotationNer', () => {
     const falsyCases = [
       {
@@ -134,139 +69,6 @@ describe('annotationUtils', () => {
     it('returns true if ner prediction', () => {
       const input = { value: 'foo', ner: { start: 4, end: 8 } }
       expect(isAnnotationNer(input)).toBeTruthy()
-    })
-  })
-
-  describe('doesOverlapWithCurrentAnnotations', () => {
-    const annotations = [{ value: 'foo', ner: { start: 2, end: 5 } }]
-
-    const emptyArrayCases = [
-      {
-        title: 'returns an empty array if annotations is a number',
-        annotations: 1,
-      },
-      { title: 'returns an empty array if annotations is null', annotations: null },
-      {
-        title: 'returns an empty array if annotations is undefined',
-        annotations: undefined,
-      },
-      {
-        title: 'returns an empty array if annotations is an empty object',
-        annotations: {},
-      },
-      {
-        title: 'returns an empty array if annotations is an empty array',
-        annotations: [],
-      },
-      {
-        title: 'returns an empty array if annotations is a string',
-        annotations: 'foo',
-      },
-      {
-        title: 'returns an empty array if annotations is an empty string',
-        annotations: '',
-      },
-      {
-        title: 'returns an empty array if start is not a number',
-        annotations,
-        start: 'foo',
-      },
-      {
-        title: 'returns an empty array if end is not a number',
-        annotations,
-        start: 1,
-        end: 'foo',
-      },
-      {
-        title: 'returns an empty array if start and end do not overlap current annotations',
-        annotations,
-        start: 8,
-        end: 10,
-      },
-    ]
-
-    emptyArrayCases.forEach(({ title, annotations: newAnnotations, start, end }) => {
-      it(title, () => {
-        expect(doesOverlapWithCurrentAnnotations(newAnnotations, start, end)).toEqual([])
-      })
-    })
-
-    const overlapCases = [
-      {
-        title:
-          'return an array with the overlapping annotation if the start is greater than the start of the annotation and less than the end of the annotation ',
-        annotations,
-        start: 3,
-        end: 4,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the start is equal than to start of the annotation and less than the end of the annotation ',
-        annotations,
-        start: 2,
-        end: 4,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the start is greater than the start of the annotation and equal to the end of the annotation ',
-        annotations,
-        start: 3,
-        end: 5,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the end is greater than the start of the annotation and less than the end of the annotation ',
-        annotations,
-        start: 3,
-        end: 4,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the end is equal to the start of the annotation and less than the end of the annotation ',
-        annotations,
-        start: 1,
-        end: 2,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the end is greater than the start of the annotation and equal to the end of the annotation ',
-        annotations,
-        start: 1,
-        end: 5,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the start is less than the start of the annotation and the end is less than the end of the annotation ',
-        annotations,
-        start: 1,
-        end: 6,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the start is greater than the start of the annotation and the end is less than the end of the annotation ',
-        annotations,
-        start: 3,
-        end: 4,
-      },
-      {
-        title: 'return an array with the overlapping annotation if the end is equal to the start of the annotation',
-        annotations,
-        start: 1,
-        end: 5,
-      },
-      {
-        title:
-          'return an array with the overlapping annotation if the start is equal to than the end of the annotation',
-        annotations,
-        start: 5,
-        end: 8,
-      },
-    ]
-
-    overlapCases.forEach(({ title, annotations: newAnnotations, start, end }) => {
-      it(title, () => {
-        expect(doesOverlapWithCurrentAnnotations(newAnnotations, start, end)).toEqual(annotations)
-      })
     })
   })
 

--- a/annotto-front/src/shared/utils/annotationUtils.js
+++ b/annotto-front/src/shared/utils/annotationUtils.js
@@ -1,30 +1,7 @@
-import { isArray, isEmpty, isEqual, isNumber, isObject, isString } from 'lodash'
-
-export const sortAndFilterNerByStart = (input) => {
-  if (!isArray(input) || isEmpty(input)) return input
-  return input.filter(({ ner }) => !!ner).sort(({ ner: { start: a } }, { ner: { start: b } }) => a - b)
-}
+import { isArray, isEqual, isNumber, isObject, isString } from 'lodash'
 
 export const isAnnotationNer = (annotation) =>
   isObject(annotation) && isNumber(annotation?.ner?.start) && isNumber(annotation?.ner?.end)
-
-export const doesOverlapWithCurrentAnnotations = (annotations, start, end) => {
-  if (isArray(annotations) && !isEmpty(annotations) && isNumber(start) && isNumber(end)) {
-    return annotations
-      .filter((a) => isAnnotationNer(a))
-      .filter(
-        ({ ner }) =>
-          (start >= ner.start && start <= ner.end) ||
-          (end >= ner.start && end <= ner.end) ||
-          (ner.start >= start && ner.end <= end) ||
-          (ner.start <= start && ner.end >= end) ||
-          ner.start === end ||
-          ner.end === start
-      )
-  }
-
-  return []
-}
 
 export const _equivalenceWrapper = (isEquivalent) => {
   return (input, other) => {
@@ -42,7 +19,7 @@ export const _isNerAnnotationEquivalent = (input, other) => {
     isNumber(other?.ner?.start) &&
     isNumber(other?.ner?.end)
   ) {
-    return input.ner.start === other.ner.start && input.ner.end === other.ner.end
+    return input.ner.start === other.ner.start && input.ner.end === other.ner.end && input?.value === other.value
   }
   return false
 }


### PR DESCRIPTION
### Description

This pull request adds the feature of managing overlaps on Named Entity Recognition (NER) annotations in Annotto. It addresses the issue #45 by allowing users to assign multiple tags to a word, even if it belongs to a previously tagged group of words.

The changes include updates to the user interface, specifically in the annotation view, to support the visualization and management of overlapping annotations.  The necessary modifications have also been made to the codebase to accommodate the new functionality, including the addition of tests to validate the behavior of the added code. Additionally, a significant refactoring of the NerContainer component has been done.

This is a non-breaking change that adds new interface features without impacting existing functionality or workflows.
Closes #(issue)

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

The changes have been thoroughly tested to ensure their effectiveness. The following tests were performed:

- Manually annotated multiple sentences with overlapping annotations and verified the correct display and management of these annotations in the user interface.
- Added unit tests to cover the new code for managing overlapping annotations.
- Ran the existing unit tests to ensure that new and existing functionality is not affected by the changes.


### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
