### PR TITLE
feat(front): Zoom on images

### DIFF
--- a/annotto-front/src/modules/project/components/common/ImageMarker.js
+++ b/annotto-front/src/modules/project/components/common/ImageMarker.js
@@ -363,12 +363,11 @@ const ImageMarker = ({
         <Styled.Img ref={imgRef} src={content} onLoad={_onLoad} style={{ width: `${zoomFactor * 100}%` }} />
         <Styled.Svg
           data-testid="__markers-container__"
-          dimensions={dimensions}
           onMouseDown={(e) => setPanStart({ x: e.clientX, y: e.clientY })}
           onMouseLeave={() => setPanStart(null)}
           onMouseUp={_onMouseUp}
           onMouseMove={_onMouseMove}
-          style={{ width: `${dimensions.width * zoomFactor}px` }}
+          style={{ width: `${dimensions.width * zoomFactor}px`, height: `${dimensions.height * zoomFactor}px` }}
         >
           {resolvedAnnotationsAndPredictions.map(({ annotationIndex, predictionIndex, zone, value }, index) => {
             const isHovered = currentHovered === index

--- a/annotto-front/src/modules/project/components/common/ImageMarker.js
+++ b/annotto-front/src/modules/project/components/common/ImageMarker.js
@@ -49,6 +49,7 @@ const ImageMarker = ({
     setCurrentHovered(null)
     setCurrentSelected(null)
     setMarkerRefs([])
+    setZoomFactor(1)
   }, [content])
 
   const resolveFourPoints = ([{ x: x1, y: y1 }, { x: x2, y: y2 }]) => [
@@ -231,7 +232,7 @@ const ImageMarker = ({
       if (isEmpty(selectedSection)) return
       if (markerRefs.some(({ current }) => current === target.parentElement)) return
       if (markerRefs.some(({ current }) => isMarkerContainsTarget(current, target))) return
-      console.log({ target, nativeEvent })
+
       addPoint({
         x: nativeEvent.offsetX / (dimensions.width * zoomFactor),
         y: nativeEvent.offsetY / (dimensions.height * zoomFactor),
@@ -346,9 +347,13 @@ const ImageMarker = ({
         <button onClick={() => setZoomFactor((old) => old - 0.1)}>minus</button>
         <button onClick={() => setZoomFactor((old) => old + 0.1)}>plus</button>
       </div>
-      <Styled.Root ref={rootRef} $haveDraggedMarker={draggedCoords.length > 0} data-testid={'__image-item__'}>
+      <Styled.Root
+        onWheel={(e) => console.log('yoo', e, e.deltaY)}
+        ref={rootRef}
+        $haveDraggedMarker={draggedCoords.length > 0}
+        data-testid={'__image-item__'}
+      >
         <Styled.Img ref={imgRef} src={content} onLoad={_onLoad} style={{ width: `${zoomFactor * 100}%` }} />
-
         <Styled.Svg
           data-testid="__markers-container__"
           dimensions={dimensions}

--- a/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
+++ b/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
@@ -1,10 +1,31 @@
-import { Button } from 'antd'
+import { Button, Slider } from 'antd'
 import { TagsOutlined } from '@ant-design/icons'
 import styled from '@xstyled/styled-components'
 
 export const Root = styled.div`
-  position: relative;
   height: 100%;
+`
+
+export const ZoomActions = styled.div`
+  position: sticky;
+  top: 1rem;
+  left: 1rem;
+  display: flex;
+  width: 80%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+`
+
+export const ZoomSlider = styled(Slider)`
+  width: 100%;
+`
+
+export const ImageWrapper = styled.div`
+  overflow: auto;
+  position: relative;
+  height: 97%;
   cursor: ${({ $haveDraggedMarker }) => ($haveDraggedMarker ? 'move' : 'auto')};
 `
 

--- a/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
+++ b/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
@@ -42,8 +42,6 @@ export const Img = styled.img`
 
 export const Svg = styled.svg`
   position: absolute;
-  height: ${({ dimensions }) => `${dimensions.height}px`};
-  width: ${({ dimensions }) => `${dimensions.width}px`};
 `
 
 export const Polygon = styled.polygon`

--- a/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
+++ b/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
@@ -3,7 +3,6 @@ import { TagsOutlined } from '@ant-design/icons'
 import styled from '@xstyled/styled-components'
 
 export const Root = styled.div`
-  overflow: auto;
   position: relative;
   height: 100%;
   cursor: ${({ $haveDraggedMarker }) => ($haveDraggedMarker ? 'move' : 'auto')};

--- a/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
+++ b/annotto-front/src/modules/project/components/common/__styles__/ImageMarker.styles.js
@@ -13,7 +13,6 @@ export const Img = styled.img`
   position: absolute;
   width: 100%;
   height: auto;
-  user-drag: none;
   user-select: none;
   -moz-user-select: none;
   -webkit-user-drag: none;

--- a/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/ImageMarker.test.js.snap
+++ b/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/ImageMarker.test.js.snap
@@ -3,41 +3,75 @@
 exports[`ImageMarker matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="sc-ZqGJI jRKgWj"
-    data-testid="__image-item__"
+    class="sc-ZqGJI bMqrSS"
   >
-    <img
-      class="sc-knEsKG dCWNq"
-    />
-    <svg
-      class="sc-cxdZMj gnjBWy"
-      data-testid="__markers-container__"
-    />
     <div
-      class="sc-bcXHqe obZLm"
-      data-testid="__loader__"
+      class="sc-knEsKG fUvFsQ"
     >
       <div
-        aria-busy="true"
-        aria-live="polite"
-        class="ant-spin ant-spin-lg ant-spin-spinning"
+        class="ant-slider sc-cxdZMj kjktuy ant-slider-horizontal"
       >
-        <span
-          class="ant-spin-dot ant-spin-dot-spin"
+        <div
+          class="ant-slider-rail"
+        />
+        <div
+          class="ant-slider-track"
+          style="left: 0%; width: 0%;"
+        />
+        <div
+          class="ant-slider-step"
+        />
+        <div
+          aria-disabled="false"
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="0"
+          class="ant-slider-handle"
+          role="slider"
+          style="left: 0%; transform: translateX(-50%);"
+          tabindex="0"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-dkKxlM knFyna"
+      data-testid="__image-item__"
+    >
+      <img
+        class="sc-gJFNMl fjyqWk"
+        style="width: 100%;"
+      />
+      <svg
+        class="sc-fxTzYC jXRoBK"
+        data-testid="__markers-container__"
+        style="width: 0px;"
+      />
+      <div
+        class="sc-bcXHqe obZLm"
+        data-testid="__loader__"
+      >
+        <div
+          aria-busy="true"
+          aria-live="polite"
+          class="ant-spin ant-spin-lg ant-spin-spinning"
         >
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-          <i
-            class="ant-spin-dot-item"
-          />
-        </span>
+          <span
+            class="ant-spin-dot ant-spin-dot-spin"
+          >
+            <i
+              class="ant-spin-dot-item"
+            />
+            <i
+              class="ant-spin-dot-item"
+            />
+            <i
+              class="ant-spin-dot-item"
+            />
+            <i
+              class="ant-spin-dot-item"
+            />
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/ImageMarker.test.js.snap
+++ b/annotto-front/src/modules/project/components/common/__tests__/__snapshots__/ImageMarker.test.js.snap
@@ -42,9 +42,9 @@ exports[`ImageMarker matches snapshot 1`] = `
         style="width: 100%;"
       />
       <svg
-        class="sc-fxTzYC jXRoBK"
+        class="sc-fxTzYC cwBKFr"
         data-testid="__markers-container__"
-        style="width: 0px;"
+        style="width: 0px; height: 0px;"
       />
       <div
         class="sc-bcXHqe obZLm"

--- a/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
+++ b/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
@@ -68,7 +68,9 @@ export const Container = styled.div`
 
 export const RightContainer = styled(Container)`
   overflow: auto;
-  max-height: calc(100vh - 64px - 40px);
+  max-height: calc(
+    100vh - 64px - 40px
+  ); // 64px is ant default header height. 40px is the padding of the root container.
   & > div:last-child {
     margin-bottom: 0;
   }

--- a/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
+++ b/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
@@ -68,6 +68,8 @@ export const Container = styled.div`
 `
 
 export const RightContainer = styled(Container)`
+  overflow: auto;
+  max-height: calc(100vh - 64px - 40px);
   & > div:last-child {
     margin-bottom: 0;
   }

--- a/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
+++ b/annotto-front/src/modules/project/components/pages/__styles__/AnnotationPage.styles.js
@@ -40,7 +40,6 @@ export const Space = styled(_Space)`
 
 export const ItemContent = styled.div`
   flex: 1;
-  overflow: auto;
   height: 0;
 `
 


### PR DESCRIPTION
<!--

Please read Annotto's Code of Conduct before submitting this PR. By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/lajavaness/annotto/blob/main/CODE_OF_CONDUCT.md

-->

### Description

User are now allowed to zoom on images. 
BBox are positionned correctly on the image after its zoomed
BBox can be created if zoom is active. 

Zoom factor goes from 1 (no zoom at all) to 3

A slider allows to change the zoom factor
If no section is selected, user can pan the image to change the scroll position (this feature is not very smooth and could be improved upon request).

<img width="937" alt="image" src="https://github.com/lajavaness/annotto/assets/105201321/7ba0657f-846c-4536-a660-01e503cd5073">


Closes #(issue)

#### Type of Change



- [x] New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### Checklist: (Feel free to delete this section upon completion)

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project (I have run `yarn lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I have run `yarn test`)
- [x] My changes generate no new warnings
